### PR TITLE
Quotes in tweets need to be encoded using urllib2.quote

### DIFF
--- a/tweet280.py
+++ b/tweet280.py
@@ -25,7 +25,7 @@ with open("cookies.txt") as f:
 sessid = "_twitter_sess="+fixcooks
 auth = "auth_token="+fixcook
 print "Enter Your Tweet:",
-tweet = raw_input()
+tweet = urllib2.quote(raw_input(), ':/')
 curl = ("curl 'https://twitter.com/i/tweet/create' -H 'Host: twitter.com' -H 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0' -H 'Accept: application/json, text/javascript, */*; q=0.01' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -H 'X-Twitter-Active-User: yes' -H 'X-Requested-With: XMLHttpRequest' -H 'Referer: https://twitter.com/' -H 'Cookie: "+sessid+"; remember_checked_on=1\"; "+auth+";' -H 'DNT: 1' -H 'Connection: keep-alive' --data 'is_permalink_page=false&page_context=profile&place_id=&status="+tweet+"&tagged_users=&weighted_character_count=true'")
 output = commands.getoutput(curl)
 if 'tweet_html' in output:


### PR DESCRIPTION
The current proof-of-concept does not work for tweets containing quotes, resulting in syntax errors "_Unterminated quoted string_", "_end of file unexpected (expecting "}")_" or the like.
Using `urllib2.quote` instead of sending the raw text input takes care of this.